### PR TITLE
Serve static files on root route

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { userRouter } from "./routes/UserRouter";
 import { photoRouter } from "./routes/PhotoRouter";
 import cors from "cors";
 import { collectionRouter } from "./routes/CollectionRouter";
+import { join } from "path";
 
 dotenv.config();
 
@@ -13,11 +14,21 @@ app.use(cors({ origin: process.env.ORIGIN || "http://localhost:3000" }));
 
 app.use(express.json());
 
+const static_dir =
+  process.env.STATIC_DIR || join("..", "labephoto-front-end", "build");
+
+app.use(express.static(join(static_dir)));
+
+app.get("/", function (req, res) {
+  console.log(__dirname);
+  res.sendFile(join(static_dir, "index.html"));
+});
+
 app.use("/user", userRouter);
 app.use("/photo", photoRouter);
 app.use("/collection", collectionRouter);
 
-var port = process.env.PORT || 4000;
+const port = process.env.PORT || 4000;
 
 const server = app.listen(port, () => {
   if (server) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,6 @@ const static_dir =
 app.use(express.static(join(static_dir)));
 
 app.get("/", function (req, res) {
-  console.log(__dirname);
   res.sendFile(join(static_dir, "index.html"));
 });
 


### PR DESCRIPTION
Add a route on the root (`/`) of the Express app to serve
static files. The idea is being able to serve both the frontend
static files and the backend APIs through the same server.

By default, the static files will be served from the `build` dir
within the `labephoto-front-end` repo. The code assumes that the
frontend repo is cloned beside the backend repo. The static dir
to be served can be overriden with the `STATIC_DIR` env var.